### PR TITLE
serve:go: Set socket file permissions to 0775.

### DIFF
--- a/cmd/k8s-kms-plugin/cmd/serve.go
+++ b/cmd/k8s-kms-plugin/cmd/serve.go
@@ -94,6 +94,10 @@ var serveCmd = &cobra.Command{
 			if grpcUNIX, err = net.Listen("unix", socketPath); err != nil {
 				return
 			}
+			// Istiod runs with uid and gid 1337, but the plugin runs with uid 0 and
+			// gid 1337.  Change the socket permissions so the group has read/write
+			// access to the socket.
+			os.Chmod(socketPath, 0775);
 			g.Go(func() error { return grpcServe(grpcUNIX) })
 			logrus.Infof("KMS Plugin Listening on : %d\n", socketPath)
 


### PR DESCRIPTION
This got lost in falling back to the v2 model.