### PR TITLE
p11: Use PEM type "RSA PRIVATE KEY" for PKCS #1 encoding.

### DIFF
--- a/pkg/providers/p11.go
+++ b/pkg/providers/p11.go
@@ -169,7 +169,7 @@ func generateSEK(ctx *crypto11.Context, request *istio.GenerateSKeyRequest, dekE
 			return
 		}
 		kpPEM := &pem.Block{
-			Type:  "PRIVATE KEY",
+			Type:  "RSA PRIVATE KEY",
 			Bytes: x509.MarshalPKCS1PrivateKey(kp),
 		}
 		buf := bytes.NewBuffer([]byte{})


### PR DESCRIPTION
The sKey was encoded with a type of "PRIVATE KEY" with PKCS #1 encoding.
That type is typically used to indicate PKCS #8 encoding.  Change the
sKey type to "RSA PRIVATE KEY" to match PKCS #1 encoding.