### PR TITLE
Remove bouk.ke monkey Go module.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
-bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/vendor/github.com/ThalesIgnite/gose/go.mod
+++ b/vendor/github.com/ThalesIgnite/gose/go.mod
@@ -1,7 +1,6 @@
 module github.com/ThalesIgnite/gose
 
 require (
-	bou.ke/monkey v1.0.2
 	github.com/ThalesIgnite/crypto11 v1.2.1
 	github.com/google/uuid v1.0.0
 	github.com/sirupsen/logrus v1.2.0

--- a/vendor/github.com/ThalesIgnite/gose/go.sum
+++ b/vendor/github.com/ThalesIgnite/gose/go.sum
@@ -1,5 +1,3 @@
-bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
-bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 github.com/ThalesIgnite/crypto11 v1.2.1 h1:KxAScWrgX9gEykv/+mU0Gzwvv7CRmrPQJOqTonsNGBY=
 github.com/ThalesIgnite/crypto11 v1.2.1/go.mod h1:vmlYtalkn8uCp3eStRZ0r7Sslmf1jAtL8De0PIyqPks=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=


### PR DESCRIPTION
It isn't used, and the license is not friendly for integrations:

    Copyright Bouke van der Bijl

    I do not give anyone permissions to use this tool for any purpose.
    Don't use it.

    I’m not interested in changing this license. Please don’t ask.