### PR TITLE
Istio: Use []byte instead of string for KEK ID in Auth Encrypt/Decrypt.

### DIFF
--- a/apis/istio/v1/messages.pb.go
+++ b/apis/istio/v1/messages.pb.go
@@ -585,7 +585,9 @@ type AuthenticatedEncryptRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	KekKid           string `protobuf:"bytes,1,opt,name=kek_kid,json=kekKid,proto3" json:"kek_kid,omitempty"`                                 // Generated out of band or via GenerateKEK
+	KekKid []byte `protobuf:"bytes,1,opt,name=kek_kid,json=kekKid,proto3" json:"kek_kid,omitempty"`
+		// Generated out of band or via GenerateKEK
+
 	EncryptedDekBlob []byte `protobuf:"bytes,2,opt,name=encrypted_dek_blob,json=encryptedDekBlob,proto3" json:"encrypted_dek_blob,omitempty"` // Encrypted DEK payload wrapped by the KEK
 	Plaintext        []byte `protobuf:"bytes,3,opt,name=plaintext,proto3" json:"plaintext,omitempty"`
 	Aad              []byte `protobuf:"bytes,4,opt,name=aad,proto3" json:"aad,omitempty"`
@@ -623,11 +625,11 @@ func (*AuthenticatedEncryptRequest) Descriptor() ([]byte, []int) {
 	return file_apis_istio_v1_messages_proto_rawDescGZIP(), []int{8}
 }
 
-func (x *AuthenticatedEncryptRequest) GetKekKid() string {
+func (x *AuthenticatedEncryptRequest) GetKekKid() []byte {
 	if x != nil {
 		return x.KekKid
 	}
-	return ""
+	return nil
 }
 
 func (x *AuthenticatedEncryptRequest) GetEncryptedDekBlob() []byte {
@@ -705,7 +707,7 @@ type AuthenticatedDecryptRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	KekKid           string `protobuf:"bytes,1,opt,name=kek_kid,json=kekKid,proto3" json:"kek_kid,omitempty"`
+	KekKid           []byte `protobuf:"bytes,1,opt,name=kek_kid,json=kekKid,proto3" json:"kek_kid,omitempty"`
 	EncryptedDekBlob []byte `protobuf:"bytes,2,opt,name=encrypted_dek_blob,json=encryptedDekBlob,proto3" json:"encrypted_dek_blob,omitempty"`
 	Ciphertext       []byte `protobuf:"bytes,3,opt,name=ciphertext,proto3" json:"ciphertext,omitempty"`
 	Aad              []byte `protobuf:"bytes,4,opt,name=aad,proto3" json:"aad,omitempty"`
@@ -743,11 +745,11 @@ func (*AuthenticatedDecryptRequest) Descriptor() ([]byte, []int) {
 	return file_apis_istio_v1_messages_proto_rawDescGZIP(), []int{10}
 }
 
-func (x *AuthenticatedDecryptRequest) GetKekKid() string {
+func (x *AuthenticatedDecryptRequest) GetKekKid() []byte {
 	if x != nil {
 		return x.KekKid
 	}
-	return ""
+	return nil
 }
 
 func (x *AuthenticatedDecryptRequest) GetEncryptedDekBlob() []byte {

--- a/apis/istio/v1/messages.proto
+++ b/apis/istio/v1/messages.proto
@@ -89,7 +89,7 @@ message LoadSKeyResponse {
 
 // AuthenticatedEncryptRequest
 message AuthenticatedEncryptRequest {
-  string kek_kid = 1; // Generated out of band or via GenerateKEK
+  bytes kek_kid = 1; // Generated out of band or via GenerateKEK
   bytes encrypted_dek_blob = 2; // Encrypted DEK payload wrapped by the KEK
   bytes plaintext = 3;
   bytes aad = 4;
@@ -102,7 +102,7 @@ message AuthenticatedEncryptResponse {
 
 // AuthenticatedDecryptRequest
 message AuthenticatedDecryptRequest {
-  string kek_kid = 1;
+  bytes kek_kid = 1;
   bytes encrypted_dek_blob = 2;
   bytes ciphertext = 3;
   bytes aad = 4;

--- a/cmd/k8s-kms-plugin/cmd/test.go
+++ b/cmd/k8s-kms-plugin/cmd/test.go
@@ -194,7 +194,7 @@ func runTest() error {
 	logrus.Info("Test 5 AuthenticatedEncrypt ")
 	var aeResp *istio.AuthenticatedEncryptResponse
 	if aeResp, err = ic.AuthenticatedEncrypt(ictx, &istio.AuthenticatedEncryptRequest{
-		KekKid: string(genKEKResp.KekKid),
+		KekKid: genKEKResp.KekKid,
 		Plaintext: []byte("Hello World"),
 		Aad: defaultAAD,
 	}); err != nil {
@@ -209,7 +209,7 @@ func runTest() error {
 	logrus.Info("Test 6 AuthenticatedDecrypt ")
 	var adResp *istio.AuthenticatedDecryptResponse
 	if adResp, err = ic.AuthenticatedDecrypt(ictx, &istio.AuthenticatedDecryptRequest{
-		KekKid:       string(genKEKResp.KekKid),
+		KekKid:       genKEKResp.KekKid,
 		EncryptedDekBlob:  genDEKResp.EncryptedDekBlob,
 		Ciphertext:   aeResp.Ciphertext,
 		Aad:          defaultAAD,

--- a/pkg/providers/p11.go
+++ b/pkg/providers/p11.go
@@ -173,7 +173,7 @@ type P11 struct {
 
 func (p *P11) AuthenticatedEncrypt(ctx context.Context, request *istio.AuthenticatedEncryptRequest) (resp *istio.AuthenticatedEncryptResponse, err error) {
 	var encryptor gose.JweEncryptor
-	if encryptor = p.encryptors[request.KekKid]; encryptor == nil {
+	if encryptor = p.encryptors[string(request.KekKid)]; encryptor == nil {
 		if encryptor, _, err = loadKEKbyID(p.ctx, []byte(request.KekKid), []byte(defaultKEKlabel)); err != nil {
 			return
 		}
@@ -190,7 +190,7 @@ func (p *P11) AuthenticatedEncrypt(ctx context.Context, request *istio.Authentic
 
 func (p *P11) AuthenticatedDecrypt(ctx context.Context, request *istio.AuthenticatedDecryptRequest) (resp *istio.AuthenticatedDecryptResponse, err error) {
 	var decryptor gose.JweDecryptor
-	if decryptor = p.decryptors[request.KekKid]; decryptor == nil {
+	if decryptor = p.decryptors[string(request.KekKid)]; decryptor == nil {
 		if _, decryptor, err = loadKEKbyID(p.ctx, []byte(request.KekKid), []byte(defaultKEKlabel)); err != nil {
 			return
 		}


### PR DESCRIPTION
Make it consistent with the other functions.