### PR TITLE
fix import typo: add import strings

### DIFF
--- a/cmd/k8s-kms-plugin/cmd/serve.go
+++ b/cmd/k8s-kms-plugin/cmd/serve.go
@@ -34,6 +34,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/ThalesIgnite/crypto11"
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
I encountered "undefined: strings" when try to build the image. It turns out the code missed this import.