### PR TITLE
github action not on PR

### DIFF
--- a/.github/workflows/Goreleaser.yaml
+++ b/.github/workflows/Goreleaser.yaml
@@ -2,7 +2,7 @@
 name: goreleaser
 
 on:
-  pull_request:
+  #pull_request:
   push:
     # run only against tags
     tags:


### PR DESCRIPTION
For now the github action CICD does not run on pull request. This might change later to include CI jobs to verify the PRs.