### PR TITLE
update slsa github action to v2

### DIFF
--- a/.github/actions/publish-release/action.yaml
+++ b/.github/actions/publish-release/action.yaml
@@ -36,7 +36,7 @@ runs:
   steps:
     # Install go with specific version
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }} # same version than the one in the go.mod or in the .go-version
      # Register to ghcr.io container Registry
@@ -48,10 +48,10 @@ runs:
         password: ${{ inputs.registry_password }} 
     # Install ko to publish container images
     - name: Set up Ko
-      uses: ko-build/setup-ko@v0.7
+      uses: ko-build/setup-ko@v0.9
     # Install cosign to sign artfacts with goreleaser 
     - name: Install Cosign
-      uses: sigstore/cosign-installer@v3.5.0
+      uses: sigstore/cosign-installer@v3.10.0
     # Get LDFLAGS with a makefile command
     - shell: bash
       name: Get LDFLAGS

--- a/.github/actions/publish-release/action.yaml
+++ b/.github/actions/publish-release/action.yaml
@@ -34,11 +34,12 @@ outputs:
 runs: 
   using: composite
   steps:
-    # Install go with specific version
+    # Install go with specific version for go build
+    - uses: actions/checkout@v5
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: ${{ inputs.go-version }} # same version than the one in the go.mod or in the .go-version
+        go-version-file: ${{ github.workspace }}/go.mod # same version than the one in the go.mod
      # Register to ghcr.io container Registry
     - name: 'Login to GitHub Container Registry'
       uses: docker/login-action@v3

--- a/.github/actions/verify-attestations/action.yaml
+++ b/.github/actions/verify-attestations/action.yaml
@@ -25,18 +25,18 @@ runs:
   steps:
     # Install go with specific version
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ inputs.go-version }} # same version than the one in the go.mod or in the .go-version
 
     - shell: bash 
       name : Install dependencies
       run : |
-        go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.5.1
+        go install github.com/slsa-framework/slsa-verifier/v2/cli/slsa-verifier@v2.7.1
     - shell: bash 
       name: verify image provenance
       id: image-provenance   
       run: |
           slsa-verifier verify-image ${{ inputs.image }} \
           --source-uri  github.com/${{github.repository}} \
-          --builder-id https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v1.10.0
+          --builder-id https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v2.1.0

--- a/.github/actions/verify-attestations/action.yaml
+++ b/.github/actions/verify-attestations/action.yaml
@@ -23,11 +23,11 @@ inputs:
 runs: 
   using: composite
   steps:
-    # Install go with specific version
+    # Install go latest stable
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: ${{ inputs.go-version }} # same version than the one in the go.mod or in the .go-version
+        go-version: 'stable'
 
     - shell: bash 
       name : Install dependencies

--- a/.github/workflows/Goreleaser.yaml
+++ b/.github/workflows/Goreleaser.yaml
@@ -22,7 +22,7 @@ jobs:
         digest: ${{ steps.publish-artifacts.outputs.digest }}
       steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
           with:
                 fetch-depth: 0      
         - name: Publish Artifacts
@@ -43,7 +43,7 @@ jobs:
         actions: read # To read the workflow path.
         id-token: write # To sign the provenance.
         contents: write # To add assets to a release.
-      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
       with:
         base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
         upload-assets: true 
@@ -54,7 +54,7 @@ jobs:
         actions: read
         id-token: write
         packages: write
-      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.10.0
+      uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
       with:
         image: ${{ needs.goreleaser.outputs.image }}
         digest: ${{ needs.goreleaser.outputs.digest }}
@@ -72,7 +72,7 @@ jobs:
         packages: write
       steps:
           - name: Checkout
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
             with:
                   fetch-depth: 0      
           - name: Verify provenance attestations

--- a/.github/workflows/Goreleaser.yaml
+++ b/.github/workflows/Goreleaser.yaml
@@ -29,7 +29,7 @@ jobs:
           id : publish-artifacts
           uses: ./.github/actions/publish-release
           with:
-            go-version: 1.23.6
+            go-version: 1.24.5
             github_token : ${{ secrets.GITHUB_TOKEN }}
             registry: ghcr.io
             registry_username: ${{ github.actor }}
@@ -79,6 +79,6 @@ jobs:
             id : slsa-verifier
             uses: ./.github/actions/verify-attestations
             with:
-              go-version: 1.23.6
+              go-version: 1.24.5
               github_token : ${{ secrets.GITHUB_TOKEN }}
               image: ${{needs.goreleaser.outputs.image}}@${{needs.goreleaser.outputs.digest}} 

--- a/.github/workflows/Goreleaser.yaml
+++ b/.github/workflows/Goreleaser.yaml
@@ -9,7 +9,6 @@ on:
       - "*"
       
 jobs:
-
     goreleaser:
       runs-on: ubuntu-latest
       env: 
@@ -29,7 +28,6 @@ jobs:
           id : publish-artifacts
           uses: ./.github/actions/publish-release
           with:
-            go-version: 1.24.5
             github_token : ${{ secrets.GITHUB_TOKEN }}
             registry: ghcr.io
             registry_username: ${{ github.actor }}
@@ -74,11 +72,10 @@ jobs:
           - name: Checkout
             uses: actions/checkout@v5
             with:
-                  fetch-depth: 0      
+              fetch-depth: 0      
           - name: Verify provenance attestations
             id : slsa-verifier
             uses: ./.github/actions/verify-attestations
             with:
-              go-version: 1.24.5
               github_token : ${{ secrets.GITHUB_TOKEN }}
               image: ${{needs.goreleaser.outputs.image}}@${{needs.goreleaser.outputs.digest}} 

--- a/README.md
+++ b/README.md
@@ -527,12 +527,10 @@ They are signed by a tool named cosign using a keyless mode.
 It required an authentication by clicking in links present in logs.
 
 ![Screenshot of one example of logs containing three authentication links generating tokens](docs/images/cosign/AuthLinksCosign.png)
-![Screenshot of one example of logs containing three authentication links generating tokens](docs/images/cosign/AuthLinksCosign.png)
 
 Once you click on one, you can submit a verification code that will redirect you to three types of authentication. Then click on Github authentication.
 
- ![Screenshot of the interface for submitting a code](docs/images/cosign/CodeSubmit.png)
- ![Screenshot of the interface for submitting a code](docs/images/cosign/CodeSubmit.png)
+![Screenshot of the interface for submitting a code](docs/images/cosign/CodeSubmit.png)
 
 Do these actions for every authentication links and the signatures and the certificates will be generated with the artifacts in the release.
 

--- a/pkg/providers/p11.go
+++ b/pkg/providers/p11.go
@@ -717,7 +717,6 @@ func (p *P11) decryptWithContext(req *k8skmsv2.DecryptRequest, isRotation bool) 
 			}
 		case jose.AlgRSAOAEP:
 			logrus.Tracef("p11:Decrypt case %s", jose.AlgRSAOAEP)
-			logrus.Tracef("p11:Decrypt case %s", jose.AlgRSAOAEP)
 			// load pkcs11 context
 			var rsaKeyPair crypto11.SignerDecrypter
 			if rsaKeyPair, err = actualCtx.FindRSAKeyPair(reqKekKeyIdByteA, nil); err != nil {
@@ -779,7 +778,6 @@ func (p *P11) Encrypt(ctx context.Context, req *k8skmsv2.EncryptRequest) (resp *
 		switch p.algorithm {
 		case jose.AlgA256GCM:
 			logrus.Tracef("p11:Encrypt case %s", jose.AlgA256GCM)
-			logrus.Tracef("p11:Encrypt case %s", jose.AlgA256GCM)
 			// Find the KEK in the KMS
 			var kek *crypto11.SecretKey
 			if kek, err = p.ctx.FindKey(p.kekCkaId, p.GetKekCkaLabelByteA()); nil != err {
@@ -812,7 +810,6 @@ func (p *P11) Encrypt(ctx context.Context, req *k8skmsv2.EncryptRequest) (resp *
 			}
 
 		case jose.AlgA256CBC:
-			logrus.Tracef("p11:Encrypt case %s", jose.AlgA256CBC)
 			logrus.Tracef("p11:Encrypt case %s", jose.AlgA256CBC)
 			// Find the KEK in the KMS
 			var kek *crypto11.SecretKey
@@ -864,7 +861,6 @@ func (p *P11) Encrypt(ctx context.Context, req *k8skmsv2.EncryptRequest) (resp *
 			}
 
 		case jose.AlgRSAOAEP:
-			logrus.Tracef("p11:Encrypt case %s", jose.AlgRSAOAEP)
 			logrus.Tracef("p11:Encrypt case %s", jose.AlgRSAOAEP)
 			//TODO generate a jwk with the kid of the public key. Ex :
 			//      {"kty":"EC",

--- a/pkg/providers/p11_test.go
+++ b/pkg/providers/p11_test.go
@@ -7,15 +7,6 @@
  * https://opensource.org/licenses/MIT.
  */
 
-/*
- * Copyright 2025 Thales Group
- * SPDX-License-Identifier: MIT
- *
- * Use of this source code is governed by an MIT-style
- * license that can be found in the LICENSE file or at
- * https://opensource.org/licenses/MIT.
- */
-
 package providers
 
 import (


### PR DESCRIPTION
- [x] Update github action to latest versions
- [x] Use `actions/setup-go@v6` with `go-version-file: ${{ github.workspace }}/go.mod` to extract version of Go from the project. This prevent from hardcoding the go version in the github action recipe.

Successfull build for tag v0.7.0-test-ci3 at https://github.com/ThalesGroup/k8s-kms-plugin/actions/runs/18287084019/workflow